### PR TITLE
Fix initialization of BatchNorm

### DIFF
--- a/Continual_Learning_Fig-2abcdefgh-3abcd-5cde/models_utils.py
+++ b/Continual_Learning_Fig-2abcdefgh-3abcd-5cde/models_utils.py
@@ -112,6 +112,11 @@ class BNN(torch.nn.Module):
                 torch.nn.init.normal_(self.layers['fc'+str(layer+1)].weight, mean=0, std=width)
             if init == "uniform":
                 torch.nn.init.uniform_(self.layers['fc'+str(layer+1)].weight, a= -width/2, b=width/2)
+
+            # In recent versions of Pytorch, the BatchNorm weights are initialized to 1.
+            # In previous versions (e.g. 1.1.0), the weights were initialized uniformly.
+            if norm == "bn":
+                torch.nn.init.uniform_(self.layers[f'bn{layer+1})'].weight)
             
     def forward(self, x):
 


### PR DESCRIPTION
# Problem

Difficulty to reproduce Fig 2.d. (sequence of pMNIST) and Fig 4.b. (MNIST-FMNIST). In recent Pytorch versions, the elements of $\gamma$ are set to 1 (cf [doc](https://pytorch.org/docs/stable/generated/torch.nn.BatchNorm1d.html#torch.nn.BatchNorm1d)). In the Pytorch version of the paper (1.1.0), elements of $\gamma$ were initialized uniformly (cf [link](https://pytorch.org/docs/1.1.0/nn.html#batchnorm1d)).

# Fix

Initialize BatchNorm weights uniformly. Currently I have only tested it with the BNN. More testing needs to be done with the BCNN and other datasets.

# Comment

I'm not sure if the PR should be merged but it will give a lead to anyone looking to reproduce the results with recent Pytorch versions.